### PR TITLE
If an item uri is empty, render it as a span.

### DIFF
--- a/Resources/views/navigation.html.twig
+++ b/Resources/views/navigation.html.twig
@@ -18,7 +18,11 @@
 {% block nav_item %}
 {% spaceless %}
     <li{% if item.active %} class="active"{% endif %}>
-        <a href="{{ item.uri }}">{{ block('label') }}</a>
+        {% if item.uri is not empty %}
+            <a href="{{ item.uri }}">{{ block('label') }}</a>
+        {% else %}
+            <span>{{ block('label') }}</span>
+        {% endif %}
     </li>
 {% endspaceless %}
 {% endblock %}


### PR DESCRIPTION
Previously, an empty uri resulted in `<a href="">Item</a>``

Solves #4
